### PR TITLE
Add better error message for Genesis node configuration.

### DIFF
--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -85,8 +85,8 @@ async function _setupGenesisNode() {
   const ledgerOwner = await _getLedgerOwner();
   const ledgerConfiguration = cfg.config;
   if(!ledgerConfiguration) {
-    throw new BedrockError('Ledger configuration not found. '
-    + '"bedrock.config[\'ledger-core\'].config" not set.', 'NotFoundError');
+    throw new BedrockError('Ledger configuration not found. ' +
+      '"bedrock.config[\'ledger-core\'].config" not set.', 'NotFoundError');
   }
   // create ledger
   const options = Object.assign({

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -84,7 +84,9 @@ async function _findAgent() {
 async function _setupGenesisNode() {
   const ledgerOwner = await _getLedgerOwner();
   const ledgerConfiguration = cfg.config;
-
+  if(!ledgerConfiguration) {
+    throw new BedrockError('Genesis node configuration required.', 'DataError');
+  }
   // create ledger
   const options = Object.assign({
     ledgerConfiguration,

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -85,7 +85,8 @@ async function _setupGenesisNode() {
   const ledgerOwner = await _getLedgerOwner();
   const ledgerConfiguration = cfg.config;
   if(!ledgerConfiguration) {
-    throw new BedrockError('Genesis node configuration required.', 'DataError');
+    throw new BedrockError('Ledger configuration not found. '
+    + '"bedrock.config[\'ledger-core\'].config" not set.', 'NotFoundError');
   }
   // create ledger
   const options = Object.assign({


### PR DESCRIPTION
Currently if you accidentally leave out the ledger configuration  then you get an error related to `database.hash` being unable to hash `null`. I'm pretty confident that we don't have any cases where the genesis node can be setup with out a configuration so this throws if `_setupGenesisNode` is called and the ledger configuration has not been set.

The Error:

```
(node:31611) UnhandledPromiseRejectionWarning: NotFoundError: Ledger configuration not found. "bedrock.config['ledger-core'].config" not set.
    at _setupGenesisNode (/work/ajones/dogwood_logic/SecureLD/node_modules/bedrock-ledger-core/lib/ledger.js:88:11)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Object.api.runOnce (/work/ajones/dogwood_logic/SecureLD/node_modules/bedrock/lib/bedrock.js:201:5)
    at async _setupLedger (/work/ajones/dogwood_logic/SecureLD/node_modules/bedrock-ledger-core/lib/ledger.js:59:3)
    at async /work/ajones/dogwood_logic/SecureLD/node_modules/bedrock-ledger-core/lib/ledger.js:27:22
    at async EventEmitter.emit (/work/ajones/dogwood_logic/SecureLD/node_modules/async-node-events/lib/main.js:146:20)
    at async _runWorker (/work/ajones/dogwood_logic/SecureLD/node_modules/bedrock/lib/bedrock.js:498:3)
    at async Object.api.start (/work/ajones/dogwood_logic/SecureLD/node_modules/bedrock/lib/bedrock.js:139:5)
(node:31611) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:31611) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```

This is low priority, but nice for customers that might use this.
Also we could just add default configs if no configs are found.

