### PR TITLE
Add bedrock-https-agent to the project.

### DIFF
--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -112,7 +112,7 @@ async function _setupPeerNode() {
   // we need to get the httpsAgent here as it starts out as null.
   const {httpsAgent} = bedrockHttpsAgent;
   if (httpsAgent === null) {
-    throw new BedrockError('Bedrock Https Agent is null.', 'InvalidStateError');
+    throw new BedrockError('Bedrock HTTPS Agent is null.', 'InvalidStateError');
   }
   const ledgerOwner = await _getLedgerOwner();
 

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -14,6 +14,7 @@ const {promisify} = require('util');
 const getAgentIterator = promisify(brLedgerAgent.getAgentIterator);
 const {config, util: {delay, BedrockError}} = bedrock;
 const {WebLedgerClient} = require('web-ledger-client');
+const bedrockHttpsAgent = require('bedrock-https-agent');
 
 // module API
 const api = {};
@@ -108,17 +109,17 @@ async function _setupGenesisNode() {
 // setup a peer node by fetching the genesis block from another peer
 async function _setupPeerNode() {
   logger.debug('Retrieving genesis block from peers', {peers: cfg.peers});
-  const {strictSSL} = config.jsonld;
-
+  // we need to get the httpsAgent here as it starts out as null.
+  const {httpsAgent} = bedrockHttpsAgent;
+  if (httpsAgent === null) {
+    throw new BedrockError('Bedrock Https Agent is null.', 'InvalidStateError');
+  }
   const ledgerOwner = await _getLedgerOwner();
 
   let genesisBlock = null;
   do {
     const hostname = _.sample(config['ledger-core'].peers);
-    const clientOptions = {hostname};
-    if(!strictSSL) {
-      clientOptions.httpsAgent = new https.Agent({rejectUnauthorized: false});
-    }
+    const clientOptions = {hostname, httpsAgent};
     const client = new WebLedgerClient(clientOptions);
     try {
       logger.debug(`Attempting to contact peer ${hostname}`);

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -14,7 +14,7 @@ const {promisify} = require('util');
 const getAgentIterator = promisify(brLedgerAgent.getAgentIterator);
 const {config, util: {delay, BedrockError}} = bedrock;
 const {WebLedgerClient} = require('web-ledger-client');
-const bedrockHttpsAgent = require('bedrock-https-agent');
+const brHttpsAgent = require('bedrock-https-agent');
 
 // module API
 const api = {};
@@ -109,8 +109,8 @@ async function _setupGenesisNode() {
 // setup a peer node by fetching the genesis block from another peer
 async function _setupPeerNode() {
   logger.debug('Retrieving genesis block from peers', {peers: cfg.peers});
-  // we need to get the httpsAgent here as it starts out as null.
-  const {httpsAgent} = bedrockHttpsAgent;
+  // we need to get the HTTPS Agent here as it starts out as null.
+  const {httpsAgent} = brHttpsAgent;
   if (httpsAgent === null) {
     throw new BedrockError('Bedrock HTTPS Agent is null.', 'InvalidStateError');
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bedrock-account": "^2.1.1",
     "bedrock-docs": "^3.0.0",
     "bedrock-express": "^2.0.8",
+    "bedrock-https-agent": "^1.0.1",
     "bedrock-identity": "^6.1.0",
     "bedrock-injector": "^1.0.0",
     "bedrock-jobs": "^3.0.0",


### PR DESCRIPTION
This replaces the use of `strictSSL` with `bedrock-https-agent`.