### PR TITLE
Use bs58 encoded string for maintainerKeySeed.

### DIFF
--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -3,7 +3,6 @@
  */
 'use strict';
 
-const crypto = require('crypto');
 const _ = require('lodash');
 const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
@@ -19,6 +18,7 @@ const brHttpsAgent = require('bedrock-https-agent');
 const {sign} = require('jsonld-signatures');
 const {Ed25519Signature2020} = require('@digitalbazaar/ed25519-signature-2020');
 const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
+const {decodeSecretKeySeed} = require('bnid');
 const didKeyDriver = require('@digitalbazaar/did-method-key').driver();
 
 // module API
@@ -101,11 +101,7 @@ async function _setupGenesisNode() {
       'TypeError'
     );
   }
-  // FIXME this should support multi-codec
-  // creates 32 byte hashes for passwords
-  const hash32 = crypto.createHash('sha256');
-  hash32.update(maintainerKeySecret);
-  const seed = hash32.digest();
+  const seed = decodeSecretKeySeed({secretKeySeed: maintainerKeySecret});
   const keyPair = await didKeyDriver.generate({seed});
   const key = keyPair.methodFor({purpose: 'capabilityInvocation'});
   const suite = new Ed25519Signature2020({key});

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   "devDependencies": {
     "eslint": "^7.0.0",
     "eslint-config-digitalbazaar": "^2.0.0"
+  },
+  "dependencies": {
+    "bnid": "^2.1.0"
   }
 }


### PR DESCRIPTION
Address this issue: https://github.com/digitalbazaar/bedrock-ledger-core/issues/13

This PR ensures that the `maintainerKeySecret` used for the initial ledger writes is a bs58 encoded multicodec string. This is the same pattern as used in `bedrock-app-identity`

This has now been tested by replacing the admin's `maintainerKeySecret` with a bs58 encoded seed material generated by:

```js
var bnid = require('bnid');
bnid.generateSecretKeySeed().then(console.log);
```

In another project. `bedrock-ledger-maintainer-cli` was also able to write a witness pool document using the bs58 encoded key.

**NOTE: merging this into `rc-2` could cause breakage in existing projects that use that branch.**